### PR TITLE
Configurable proxy destination + dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:8-alpine
+ADD . /
+EXPOSE 6617
+CMD ["node","index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:8-alpine
+RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
 ADD . /
 EXPOSE 6617
 CMD ["node","index.js"]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ usage:
 	http://localhost:6617/shimondoodkin/rawgithub/master/index.js
 	
 	notice the change from https to http
+
+## Configurable destination
+
+If you have a local/enterprise git repo and want to have the same functionality, you can now pass the URL of that repository via
+an environment variable called GIT_PROXY_DEST. If absent, the proxy will still point to github.
+
+## Docker
+
+There is a dockerfile that turns it into a ready to use container. You can check it out on [dockerhub](https://hub.docker.com/r/kullervo16/rawgithub/)

--- a/index.js
+++ b/index.js
@@ -3,11 +3,17 @@ var url = require('url');
 var mime = require('mime');
 var request = require('request');
 
+var remoteUrl = process.env.GIT_PROXY_DEST;
+if (remoteUrl === undefined) {
+    remoteUrl = 'https://raw.github.com';
+}
+
+
 http.createServer(function (req, res) {
-    console.log('http://raw.github.com'+req.url);
-	request('https://raw.github.com'+req.url, function (error, response, body) {
+    console.log(remoteUrl+req.url);
+	request(remoteUrl+req.url, function (error, response, body) {
 	  	res.writeHead(response.statusCode, {'Content-Type': mime.lookup(req.url,'text/html')+';charset=utf-8'});
 		res.end(body);
 	});
 }).listen(6617, '127.0.0.1');
-console.log('Github Server running at http://127.0.0.1:6617/');
+console.log('Github Server running at http://127.0.0.1:6617/. Proxying to '+remoteUrl);

--- a/index.js
+++ b/index.js
@@ -15,5 +15,5 @@ http.createServer(function (req, res) {
 	  	res.writeHead(response.statusCode, {'Content-Type': mime.lookup(req.url,'text/html')+';charset=utf-8'});
 		res.end(body);
 	});
-}).listen(6617, '127.0.0.1');
-console.log('Github Server running at http://127.0.0.1:6617/. Proxying to '+remoteUrl);
+}).listen(6617, '0.0.0.0');
+console.log('Github Server running at http://0.0.0.0:6617/. Proxying to '+remoteUrl);


### PR DESCRIPTION
Hello,

your project did exactly what I needed, but for the public github.com... while I need it for my private enterprise repo. So I made it configurable and added a Docker file so that you can run it out-of-the-box without installing node.

Jef